### PR TITLE
fix: unload client account when connection drops

### DIFF
--- a/src/plugins/client.ts
+++ b/src/plugins/client.ts
@@ -29,16 +29,18 @@ export class LightningClientPlugin extends BtpPlugin implements PluginInstance {
 
     this.getAccount = () => getAccount('peer')
     this.loadAccount = () => loadAccount('peer')
+
+    this.on('disconnect', () => this.getAccount().unload())
+
+    this.on('connect', async () => {
+      const account = await this.loadAccount()
+      account.emit('connected')
+      return account.connect()
+    })
   }
 
   _sendMessage(accountName: string, message: BtpPacket) {
     return this._call('', message)
-  }
-
-  async _connect(): Promise<void> {
-    const account = await this.loadAccount()
-    account.emit('connected')
-    return account.connect()
   }
 
   _handleData(from: string, message: BtpPacket): Promise<BtpSubProtocol[]> {


### PR DESCRIPTION
When plugin-btp auto reconnects, this triggers the account to reload and share a new set of invoices. Previously, if the connection dropped, the server would become unable to pay the client because the client wouldn't share new invoices.

Also, remove event listeners that weren't properly cleaned up.
