### PR TITLE
fix: do not peer on connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ This plugin uses the [Bilateral Transfer Protocol](https://github.com/interledge
 
 #### `peeringRequest`
 
-- Format: `[Identity public key]@[hostname]:[port]`, UTF-8 encoded
-- Used for sharing peering information of our Lightning node with the peer
-- The receiver of the message will subsequently attempt to peer over the Lightning network
+- Format: `[Identity public key]`, UTF-8 encoded
+- Used for sharing pubkey of our Lightning node with the peer
+- Only shares pubkey, does not attempt to peer over the Lightning network
 
 #### `paymentRequest`
 

--- a/src/account.ts
+++ b/src/account.ts
@@ -20,7 +20,7 @@ import { BehaviorSubject } from 'rxjs'
 import { promisify } from 'util'
 import LightningPlugin from '.'
 import { lnrpc } from '../generated/rpc'
-import { connectPeer, createPaymentRequest, payInvoice } from './lightning'
+import {createPaymentRequest, payInvoice } from './lightning'
 import { DataHandler, MoneyHandler } from './types/plugin'
 
 // Used to denominate which asset scale we are using
@@ -179,8 +179,6 @@ export default class LightningAccount {
         this.master._log.debug(
           `Attempting to peer over Lightning with ${identityPublicKey}`
         )
-
-        await connectPeer(this.master._lightning)(identityPublicKey, host)
 
         this.peerIdentityPublicKey = identityPublicKey
         this.master._log.info(`Successfully peered with ${identityPublicKey}`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -219,7 +219,7 @@ export default class LightningPlugin extends EventEmitter2
 
     // Fetch public key & host for peering directly from LND
     const response = await this._lightning.getInfo({})
-    this._lightningAddress = response.uris[0]
+    this._lightningAddress = response.identityPubkey
 
     /*
      * Create only a single HTTP/2 stream per-plugin for


### PR DESCRIPTION
fixes https://github.com/interledgerjs/ilp-plugin-lightning/issues/31

In the future, if we want to support opening of channels between servers/clients we can re-implement peering, although it shouldn't happen automatically on connect. 